### PR TITLE
fix(ci): decouple checkout from GH_TOKEN in random.yml

### DIFF
--- a/.github/workflows/random.yml
+++ b/.github/workflows/random.yml
@@ -13,9 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # GH_TOKEN needs repo + read:project + project scopes; persists for the
-          # later git push step so we don't have to inject the token into the URL.
-          token: ${{ secrets.GH_TOKEN }}
+          # Checkout with the default GITHUB_TOKEN so this step never depends
+          # on GH_TOKEN being valid. GH_TOKEN is only used where it's actually
+          # needed (project GraphQL + final push).
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -27,15 +28,18 @@ jobs:
 
       - name: Random Dare
         env:
+          # GH_TOKEN needs repo + read:project + project scopes.
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHANNEL_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
         run: uv run python -m random_dare.pick
 
       - name: Commit
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           git config --local user.email "i@niracler.com"
           git config --local user.name "niracler"
           git add README.md data/table.csv
           git commit -m "docs: random dare $(date +'%Y-%m-%d')"
-          git push origin main
+          git push "https://x-access-token:${GH_TOKEN}@github.com/niracler/random.git" HEAD:main


### PR DESCRIPTION
## Summary
- 5/1 的 Random Dare 定时跑挂在 `actions/checkout` — `fatal: could not read Username for 'https://github.com'`,根因是 4/27 refactor 把 `token: ${{ secrets.GH_TOKEN }}` 加到了 checkout 上,而那个 PAT 已经过期/失效,于是 job 第一步就 fail。
- 把 checkout 改回默认 `GITHUB_TOKEN` + `persist-credentials: false`,GH_TOKEN 只留给真正需要它的两步:Python 脚本(查 ProjectV2)和最后的 `git push`(显式带 token URL)。
- 这样以后 GH_TOKEN 再坏,checkout 不会受影响,失败会落在真正出问题的步骤上,排查更快。

## Test plan
- [ ] 在 GitHub settings 重新生成 GH_TOKEN PAT(`repo` + `read:project` + `project` scopes),更新到 repo secret —— **本 PR 不修这个,只缩小爆炸半径**
- [ ] 合并后跑一次 `workflow_dispatch` 触发 Random Dare,确认 checkout 通过
- [ ] 确认 `uv run python -m random_dare.pick` 能正常拉到 project items(token 续上后)
- [ ] 确认最后 `git push` 成功推到 main

https://claude.ai/code/session_01GC9wCxEa1SeQv7QvqvCRdo

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC9wCxEa1SeQv7QvqvCRdo)_